### PR TITLE
fixed the permitted branch name for deployment

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,4 +19,4 @@ deploy:
   handler_name: "handler"
   runtime: "python3.6"
   on:
-    branch: develop
+    branch: dev


### PR DESCRIPTION
Deployment was prevented due to the wrong name for permitted branch for deployment.  Fixed the issue and trying again.